### PR TITLE
'npm run macintosh' でmacの読み上げ機能を使える様に変更．

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "robot": "node robot-server.js",
     "robot-dev": "SPEECH=off node robot-server.js",
+    "macintosh": "SPEECH=off MACINTOSH=on node robot-server.js",
     "button": "./button-server.sh",
     "servo": "sudo node servo-head.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/robot-server.js
+++ b/robot-server.js
@@ -20,7 +20,8 @@ const quiz_master = process.env.QUIZ_MASTER || '_quiz_master_';
 var context = null;
 var led_mode = 'auto';
 
-talk.dummy = (process.env['SPEECH'] === 'off');
+talk.dummy = (process.env['SPEECH'] === 'off' && process.env['MACINTOSH'] !== 'on');
+talk.macvoice = (process.env['MACINTOSH'] === 'on');
 
 var robotDataPath = process.argv[2] || 'robot-data.json';
 

--- a/talk-mac-Kyoko.sh
+++ b/talk-mac-Kyoko.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo $@
+say -v Kyoko $@

--- a/talk-mac-Otoya.sh
+++ b/talk-mac-Otoya.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo $@
+say -v Otoya $@

--- a/talk.js
+++ b/talk.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const spawn = require('child_process').spawn;
 const path = require('path');
+const macvoice_speedrate = 180 / 100;
 
 function Talk() {
 	var t = new EventEmitter();
@@ -10,6 +11,7 @@ function Talk() {
 	t.speed = 95;
 	t.volume = 80;
 	t.dummy = false;
+	t.macvoice = false;
 
   t.say = function(words, params, callback) {
   	const voice = params.voice;
@@ -29,6 +31,18 @@ function Talk() {
       console.log(cont);
 			if (this.dummy) {
 				playone();
+			} else if (this.macvoice) {
+				if (voice == 'marisa') {
+					const _playone = spawn(path.join(__dirname, 'talk-mac-Otoya.sh'), [`-r`, speed * macvoice_speedrate, `　${cont}`]);
+					_playone.on('close', function (code) {
+						playone();
+					});
+				} else {
+					const _playone = spawn(path.join(__dirname, 'talk-mac-Kyoko.sh'), [`-r`, speed * macvoice_speedrate, `　${cont}`]);
+					_playone.on('close', function (code) {
+						playone();
+					});
+				}
 			} else {
 				if (voice == 'marisa') {
 					const _playone = spawn(path.join(__dirname,'talk-f2.sh'), [`-s`, speed, `-g`, volume, `　${cont}`]);


### PR DESCRIPTION
```npm run macintosh```
でmacの読み上げ機能(sayコマンド)を使える様にしました．
使うためには，
システム環境設定 -> アクセシビリティ -> スピーチ -> システムの声
で "Kyoko" と "Otoya" をインストールしておく必要があります．
node-redで制御する際は，それぞれ「霊夢」が"Kyoko"，「魔理沙」が"Otoya"の声になります．
レビューおよび，問題がなければマージをお願いします．